### PR TITLE
ID's path and console/clipboard output when no `_tracUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ An extension to inspect details of elements.
 "_inspector": {
 	"_isEnabled": true,
 	"_tracUrl": ""
+    "_sendTo":""
 }
 ```
 * Toggle `_isEnabled` to turn Inspector on or off.
 * Populate `_tracUrl` to make element IDs clickable to a specific Trac.
+* Populate `_sendTo` to get details  sent to "console" or "clipboard" when `_tracUrl` is not populated.
 * With [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run `adapt install inspector`. Alternatively, download the ZIP and extract into the src > extensions directory.
 * Run an appropriate Grunt task.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An extension to inspect details of elements.
 "_inspector": {
 	"_isEnabled": true,
 	"_tracUrl": ""
-    "_sendTo":""
+	"_sendTo": ""
 }
 ```
 * Toggle `_isEnabled` to turn Inspector on or off.

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ An extension to inspect details of elements.
 ## Usage
 
 * Elements are annotated on hover with their types and IDs.
-* Click the element IDs to create tickets on Trac.
+* Click the element IDs to create tickets on Trac or when `_tracUrl` is empty and `_sendTo` has correct value to send details to console or clipboard.
 * Roll over the IDs for tooltips containing additional details.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An extension to inspect details of elements.
 ```json
 "_inspector": {
 	"_isEnabled": true,
-	"_tracUrl": ""
+	"_tracUrl": "",
 	"_sendTo": ""
 }
 ```

--- a/example.json
+++ b/example.json
@@ -1,4 +1,5 @@
 "_inspector": {
 	"_isEnabled": true,
-	"_tracUrl": ""
+	"_tracUrl": "",
+    "_sendTo":"console"
 }

--- a/example.json
+++ b/example.json
@@ -1,5 +1,5 @@
 "_inspector": {
 	"_isEnabled": true,
 	"_tracUrl": "",
-    "_sendTo":"console"
+	"_sendTo":"console"
 }

--- a/js/adapt-inspector.js
+++ b/js/adapt-inspector.js
@@ -43,7 +43,7 @@ define(function(require) {
 			this.checkMargin(this.$(".inspector"));
 			this.addTracUrl();
 
-            this.sendTo = Adapt.config.get("_inspector")._sendTo;
+			this.sendTo = Adapt.config.get("_inspector")._sendTo;
             
 			return this;
 		},
@@ -64,7 +64,7 @@ define(function(require) {
 			$element.css({ "left": "", "margin-left": "" });
 			$element.css({ "left": "50%", "margin-left": minusHalfWidth() });
 		},
-        getTracDetails: function(){
+		getTracDetails: function(){
 			var title = $("<div/>").html(this.model.get("displayTitle")).text();
 			var id = this.model.get("_id");
             
@@ -75,23 +75,23 @@ define(function(require) {
 			if (title) params += " " + title;
 			if (id !== location) params += " (" + locationType + " " + location + ")";
             
-            params +=  ", path:"+this.getIdPath();
+			params +=  ", path:"+this.getIdPath();
             
-            return params;
-        },
-        getIdPath: function (){
-            var model = this.model;
-            var ids = [];
-            while(model != null) {
-                ids.unshift(model.get("_id"));
-                if(model.get("_type") === "course") break;//end of journey
-                model = model.getParent();
-            }
-            return ids.join(" > ");
-        },
-        copyToClipboard: function(text) {
-            window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
-        },
+			return params;
+		},
+		getIdPath: function (){
+			var model = this.model;
+			var ids = [];
+			while(model != null) {
+				ids.unshift(model.get("_id"));
+				if(model.get("_type") === "course") break;//end of journey
+				model = model.getParent();
+			}
+			return ids.join(" > ");
+		},
+		copyToClipboard: function(text) {
+			window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
+		},
 		addTracUrl: function() {
 			this.tracUrl = Adapt.config.get("_inspector")._tracUrl;
 
@@ -104,18 +104,18 @@ define(function(require) {
 		},
 
 		onClickDisabled: function() {
-            try {
-                if(!this.sendTo || this.sendTo == "") return false;
+			try {
+				if(!this.sendTo || this.sendTo == "") return false;
                 
-                var details = this.getTracDetails();
+				var details = this.getTracDetails();
                 
-                if(this.sendTo == "console") {
-                    console.log(details);
-                }
-                else if(this.sendTo == "clipboard"){
-                    this.copyToClipboard(details);
-                }
-            } catch(e){ console.error(e); }
+				if(this.sendTo == "console") {
+					console.log(details);
+				}
+				else if(this.sendTo == "clipboard"){
+					this.copyToClipboard(details);
+				}
+			} catch(e){ console.error(e); }
             
 			return false;
 		},

--- a/js/adapt-inspector.js
+++ b/js/adapt-inspector.js
@@ -43,6 +43,8 @@ define(function(require) {
 			this.checkMargin(this.$(".inspector"));
 			this.addTracUrl();
 
+            this.sendTo = Adapt.config.get("_inspector")._sendTo;
+            
 			return this;
 		},
 
@@ -62,26 +64,59 @@ define(function(require) {
 			$element.css({ "left": "", "margin-left": "" });
 			$element.css({ "left": "50%", "margin-left": minusHalfWidth() });
 		},
-
-		addTracUrl: function() {
-			this.tracUrl = Adapt.config.get("_inspector")._tracUrl;
-
-			if (!this.tracUrl) return this.$(".inspector").addClass("trac-url-disabled");
-
+        getTracDetails: function(){
 			var title = $("<div/>").html(this.model.get("displayTitle")).text();
 			var id = this.model.get("_id");
+            
 			var location = Adapt.location._currentId;
 			var locationType = Adapt.location._contentType;
 			var params = id;
 			
 			if (title) params += " " + title;
 			if (id !== location) params += " (" + locationType + " " + location + ")";
+            
+            params +=  ", path:"+this.getIdPath();
+            
+            return params;
+        },
+        getIdPath: function (){
+            var model = this.model;
+            var ids = [];
+            while(model != null) {
+                ids.unshift(model.get("_id"));
+                if(model.get("_type") === "course") break;//end of journey
+                model = model.getParent();
+            }
+            return ids.join(" > ");
+        },
+        copyToClipboard: function(text) {
+            window.prompt("Copy to clipboard: Ctrl+C, Enter", text);
+        },
+		addTracUrl: function() {
+			this.tracUrl = Adapt.config.get("_inspector")._tracUrl;
+
+			if (!this.tracUrl) return this.$(".inspector").addClass("trac-url-disabled");
+
+                var details = this.getTracDetails();
 
 			this.$(".inspector").attr("href", this.tracUrl + "/newticket?summary=" +
-				encodeURIComponent(params));
+				encodeURIComponent(details));
 		},
 
 		onClickDisabled: function() {
+            try {
+                if(!this.sendTo || this.sendTo == "") return false;
+                
+                var details = this.getTracDetails();
+                
+                if(this.sendTo == "console") {
+                    console.log(details);
+                }
+                else if(this.sendTo == "clipboard"){
+                    this.copyToClipboard(details);
+                }
+            } catch(e){ console.error(e); }
+            
 			return false;
 		},
 


### PR DESCRIPTION
Adds the "path id" functionality which outputs the "id" path
Adds the `_sendTo` feature when no `_tracUrl` defined so the details are sent to console or clipboard, below are examples of output:

```
course Welcome to Adapt Learning - v2.0.0, path:course
co-20 Question components (menu co-10), path:course > co-10 > co-20
a-30 An introduction to our Question Components (page co-20), path:course > co-10 > co-20 > a-30
b-55 (page co-20), path:course > co-10 > co-20 > a-30 > b-55
c-110 Matching (page co-20), path:course > co-10 > co-20 > a-30 > b-55 > c-110
```
