### PR TITLE
Added alternative to stopPropagation

### DIFF
--- a/js/adapt-inspector.js
+++ b/js/adapt-inspector.js
@@ -156,7 +156,8 @@ define([ "coreJS/adapt" ], function(Adapt) {
 		},
 
 		onTouch: function(event) {
-			event.stopPropagation();
+			if (event.originalEvent.inspectorStop) return;
+			event.originalEvent.inspectorStop = true;
 
 			$("#wrapper").trigger(jQuery.Event("touchend"));
 

--- a/js/adapt-inspector.js
+++ b/js/adapt-inspector.js
@@ -159,8 +159,6 @@ define([ "coreJS/adapt" ], function(Adapt) {
 			if (event.originalEvent.inspectorStop) return;
 			event.originalEvent.inspectorStop = true;
 
-			$("#wrapper").trigger(jQuery.Event("touchend"));
-
 			if (!$(event.target).is("[class*=inspector-]")) {
 				Adapt.trigger("inspector:touch", this.$el);
 			}


### PR DESCRIPTION
Touch event variables not being passed through with current method as a new event is created.
